### PR TITLE
Some typos in the uncertainty module

### DIFF
--- a/uncertainty/1-lesson_descriptive_statistics.ipynb
+++ b/uncertainty/1-lesson_descriptive_statistics.ipynb
@@ -185,7 +185,7 @@
     "\n",
     "\n",
     "Some useful properties of the variance:\n",
-    "- non negative: $\\text{Var}(\\mathcal{X}) \\leq 0$\n",
+    "- non-negative: $\\text{Var}(\\mathcal{X}) \\geq 0$\n",
     "- translation invariant: $\\text{Var}(\\mathcal{X}) = \\text{Var}(\\mathcal{X}+a)$\n",
     "\n",
     "The variance is also known as the second **central** moment.\n",

--- a/uncertainty/1-lesson_descriptive_statistics.ipynb
+++ b/uncertainty/1-lesson_descriptive_statistics.ipynb
@@ -280,7 +280,7 @@
     "## One more type of moment...\n",
     "\n",
     "The last type of moment is the **standardized moment**.\n",
-    "As for the two other types of moments we saw, there is a general definition for the  $k$-th standardized moment, but two most popular are the third standardized moment (i.e., skewness) and the forth standardized moment (i.e.,  kurtosis).\n",
+    "As for the two other types of moments we saw, there is a general definition for the  $k$-th standardized moment, but two most popular are the third standardized moment (i.e., skewness) and the fourth standardized moment (i.e.,  kurtosis).\n",
     "Standardized moments are useful as they describe a set in a way that is scale invariant (i.e., invariant to multiply the whole set by a constant (e.g., $a \\mathcal{X} = \\{a x_1, a x_2, \\dots, a x_i\\}$).\n",
     "\n",
     "Skewness gives an idea of how much the set is symmetric, with a skewness of zero meaning perfect symmetry, such as a Gaussian or a uniform distribution.\n",


### PR DESCRIPTION
Hi!

I spotted a small typo with the non-negative property of the variance, it should be `Var(X) >= 0` and not `Var(X) <= 0`.

There was also a `forth` that should be `fourth`.